### PR TITLE
fix: use position of original source to insert global assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.2.2-beta.0](https://github.com/fossamagna/gas-webpack-plugin/compare/v2.2.1...v2.2.2-beta.0) (2022-06-15)
+
+
+### Bug Fixes
+
+* use position of original source to insert global assignments ([4c76d11](https://github.com/fossamagna/gas-webpack-plugin/commit/4c76d11c6dd7eef856fd14a2f6ce245f92a118f4))
+
+
+
 ## [2.2.1](https://github.com/fossamagna/gas-webpack-plugin/compare/v2.2.0...v2.2.1) (2022-03-31)
 
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ GasDependency.Template = class GasDependencyTemplate {
     const output = generate(originalSource, options);
     this.entryFunctions.set(module, output);
     if (output.globalAssignments) {
-      source.insert(source.size(), output.globalAssignments);
+      source.insert(originalSource.length, output.globalAssignments);
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gas-webpack-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gas-webpack-plugin",
-      "version": "2.2.1",
+      "version": "2.2.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "gas-entry-generator": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gas-webpack-plugin",
       "version": "2.2.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-webpack-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2-beta.0",
   "description": "Webpack Plugin for Google Apps Script",
   "main": "index.js",
   "types": "types.d.ts",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "test",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
fix #719 